### PR TITLE
Drop obsolete legacy Send method from Session type

### DIFF
--- a/session.go
+++ b/session.go
@@ -15,20 +15,6 @@ func (s *session) Reset() {
 	s.c.Reset()
 }
 
-func (s *session) Send(from string, to []string, r io.Reader) error {
-	if err := s.Mail(from); err != nil {
-		return err
-	}
-
-	for _, rcpt := range to {
-		if err := s.Rcpt(rcpt); err != nil {
-			return err
-		}
-	}
-
-	return s.Data(r)
-}
-
 func (s *session) Mail(from string) error {
 	return s.c.Mail(from)
 }


### PR DESCRIPTION
As mentioned in the review of PR #2.