### PR TITLE
Add an ability to set client's hostname

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -23,6 +23,7 @@ type Backend struct {
 	TLSConfig *tls.Config
 	LMTP      bool
 	Host      string
+	LocalName string
 
 	unexported struct{}
 }
@@ -77,6 +78,13 @@ func (be *Backend) newConn() (*smtp.Client, error) {
 	}
 	if err != nil {
 		return nil, err
+	}
+
+	if be.LocalName != "" {
+		err = c.Hello(be.LocalName)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if be.Security == SecurityStartTLS {


### PR DESCRIPTION
This change allows the proxy server to set its own hostname instead of default `localhost`